### PR TITLE
D.T Storage - #23 - Each D.T Instance Gets It's Own Subfolder

### DIFF
--- a/disciple-tools-storage-filters.php
+++ b/disciple-tools-storage-filters.php
@@ -256,7 +256,7 @@ function dt_storage_connections_obj_upload( $response, $storage_connection_id, $
                     $bucket = $config['bucket'];
 
                     //Create a folder for the current site in case a bucket is shared between multiple sites.
-                    $dt_site_id = get_option( 'dt_site_id' );
+                    $dt_site_id = dt_site_id();
                     $site_key = substr( $dt_site_id, 0, 30 );
 
                     // Ensure duplicate site id prefixes are handled accordingly.


### PR DESCRIPTION
- fixes: #23 
---

I can confirm subfolder logic was already in place; using a hashed version of D.T instance. The update simply swaps out the initial direct site-id option call for a more robust function call.

The following screenshots show both single sites and multisite sub-site subfolders; as well as the content of a typical subfolder; which contextually groups assets.

<img width="1356" height="858" alt="Screenshot 2025-07-25 at 13 48 12" src="https://github.com/user-attachments/assets/7439085f-0bfb-4dd7-a298-f4f3e834d1f7" />

<img width="1358" height="532" alt="Screenshot 2025-07-25 at 13 54 20" src="https://github.com/user-attachments/assets/62816b96-2c92-46ab-9ddb-37419e90302c" />
